### PR TITLE
Add calendar and even pydantic data model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,15 @@ repos:
     # use require_serial so that script
     # is only called once per commit
     require_serial: true
+- repo: local
+  hooks:
+  - id: pylint
+    name: pylint
+    entry: pylint
+    language: system
+    types: [python]
+    args:
+      [
+        "-rn", # Only display messages
+        "-sn", # Don't display the score
+      ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,15 @@ repos:
   rev: 4.0.1
   hooks:
   - id: flake8
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.942
+- repo: local
   hooks:
   - id: mypy
-    additional_dependencies: [types-PyYAML,pytest-aiohttp,types-protobuf]
-    args: ['--no-warn-unused-ignores']
+    name: mypy
+    entry: "./run-mypy"
+    language: python
+    language_version: python3.9
+    additional_dependencies: ["mypy==0.930"]
+    types: [python]
+    # use require_serial so that script
+    # is only called once per commit
+    require_serial: true

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MASTER]
+extension-pkg-whitelist=pydantic
+disable = no-self-use, no-self-argument

--- a/google_calendar_sync/model.py
+++ b/google_calendar_sync/model.py
@@ -1,0 +1,51 @@
+"""Library for data model for local calendar objects."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel, validator
+
+DATE_STR_FORMAT = "%Y-%m-%d"
+
+
+class Calendar(BaseModel):
+    """Metadata associated with a calendar."""
+
+    id: str
+    summary: str
+    description: Optional[str]
+    location: Optional[str]
+    timezone: Optional[str]
+
+
+class Event(BaseModel):
+    """A single event on a calendar."""
+
+    id: str
+    summary: str
+    start: Union[datetime.datetime, datetime.date]
+    end: Union[datetime.datetime, datetime.date]
+    description: Optional[str]
+    location: Optional[str]
+
+    @validator("start", pre=True)
+    def start_date_from_api(cls, v: Any) -> Union[datetime.date, datetime.datetime]:
+        if not isinstance(v, dict):
+            raise ValueError("Unexpected value was not dictionary")
+        if "dateTime" in v:
+            return datetime.datetime.fromisoformat(v["dateTime"])
+        if "date" in v:
+            return datetime.datetime.strptime(v["date"], DATE_STR_FORMAT).date()
+        raise ValueError("Unexpected missing date or dateTime value")
+
+    @validator("end", pre=True)
+    def end_date_from_api(cls, v: Any) -> Union[datetime.date, datetime.datetime]:
+        if not isinstance(v, dict):
+            raise ValueError("Unexpected value was not dictionary")
+        if "dateTime" in v:
+            return datetime.datetime.fromisoformat(v["dateTime"])
+        if "date" in v:
+            return datetime.datetime.strptime(v["date"], DATE_STR_FORMAT).date()
+        raise ValueError("Unexpected missing date or dateTime value")

--- a/google_calendar_sync/model.py
+++ b/google_calendar_sync/model.py
@@ -38,6 +38,7 @@ class Datetime(BaseModel):
 
     @root_validator
     def check_date_or_datetime(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate the date or datetime fields are set properly."""
         if not values.get("date") and not values.get("date_time"):
             raise ValueError("Unexpected missing date or dateTime value")
         return values

--- a/google_calendar_sync/store.py
+++ b/google_calendar_sync/store.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from abc import ABC
+from typing import Any
 
 
 class CalendarStore(ABC):
     """Interface for external calendar storage."""
 
-    async def async_load(self) -> dict | None:
+    async def async_load(self) -> dict[str, Any] | None:
         """Load data."""
 
-    async def async_save(self, data: dict) -> None:
+    async def async_save(self, data: dict[str, Any]) -> None:
         """Save data."""
 
 
@@ -19,12 +20,12 @@ class InMemoryCalendarStore(CalendarStore):
     """An in memory implementation of CalendarStore."""
 
     def __init__(self) -> None:
-        self._data: dict | None = None
+        self._data: dict[str, Any] | None = None
 
-    async def async_load(self) -> dict | None:
+    async def async_load(self) -> dict[str, Any] | None:
         """Load data."""
         return self._data
 
-    async def async_save(self, data: dict) -> None:
+    async def async_save(self, data: dict[str, Any]) -> None:
         """Save data."""
         self._data = data

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,15 +1,24 @@
 [mypy]
+plugins = pydantic.mypy
 ignore_missing_imports = True
 exclude = (venv|build)
 check_untyped_defs = True
+disallow_any_generics = True
 disallow_incomplete_defs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
 no_implicit_optional = True
+no_implicit_reexport = True
 warn_return_any = True
 warn_unreachable = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 warn_no_return = True
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
+warn_untyped_fields = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,11 @@ coverage==6.3.2
 flake8-black==0.2.3
 flake8==4.0.1
 google-api-python-client==2.38.0
-mypy==0.942
+mypy==0.930
 pre-commit==2.18.1
+pydantic==1.9.0
 pylint==2.13.5
 pytest==6.2.5
 pytest-asyncio==0.18.3
 pytest-cov==3.0.0
+pytz==2022.1

--- a/run-mypy
+++ b/run-mypy
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+# Change directory to the project root directory.
+cd "$(dirname "$0")"
+
+pip3 install -r requirements.txt --no-input --quiet
+
+mypy .

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -84,20 +84,24 @@ def test_event_datetime() -> None:
     assert event.summary == "Event summary"
     assert event.description is None
     assert event.location is None
-    tz = datetime.timezone(datetime.timedelta(hours=-8))
+    tzinfo = datetime.timezone(datetime.timedelta(hours=-8))
 
     assert event.start
     assert event.start.date is None
     assert event.start.date_time
-    assert event.start.date_time == datetime.datetime(2022, 4, 12, 16, 30, 0, tzinfo=tz)
+    assert event.start.date_time == datetime.datetime(
+        2022, 4, 12, 16, 30, 0, tzinfo=tzinfo
+    )
     assert event.start.timezone is None
-    assert event.start.value == datetime.datetime(2022, 4, 12, 16, 30, 0, tzinfo=tz)
+    assert event.start.value == datetime.datetime(2022, 4, 12, 16, 30, 0, tzinfo=tzinfo)
 
     assert event.end
     assert event.end.date is None
-    assert event.end.date_time == datetime.datetime(2022, 4, 12, 17, 0, 0, tzinfo=tz)
+    assert event.end.date_time == datetime.datetime(
+        2022, 4, 12, 17, 0, 0, tzinfo=tzinfo
+    )
     assert event.end.timezone is None
-    assert event.end.value == datetime.datetime(2022, 4, 12, 17, 0, 0, tzinfo=tz)
+    assert event.end.value == datetime.datetime(2022, 4, 12, 17, 0, 0, tzinfo=tzinfo)
 
 
 def test_invalid_datetime() -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,80 @@
+"""Tests for the data model."""
+
+import datetime
+
+from google_calendar_sync.model import Calendar, Event
+
+
+def test_calendar() -> None:
+    """Exercise basic parsing of a calendar API response."""
+
+    calendar = Calendar.parse_obj(
+        {
+            "kind": "calendar#calendarListEntry",
+            "id": "some-calendar-id",
+            "summary": "Calendar summary",
+            "description": "Calendar description",
+            "location": "Some location",
+            "hidden": False,
+        }
+    )
+    assert calendar.id == "some-calendar-id"
+    assert calendar.summary == "Calendar summary"
+    assert calendar.description == "Calendar description"
+    assert calendar.location == "Some location"
+    assert calendar.timezone is None
+
+
+def test_event_with_date() -> None:
+    """Exercise basic parsing of an event API response."""
+
+    event = Event.parse_obj(
+        {
+            "kind": "calendar#event",
+            "id": "some-event-id",
+            "status": "some-status",
+            "summary": "Event summary",
+            "description": "Event description",
+            "location": "Event location",
+            "start": {
+                "date": "2022-04-12",
+            },
+            "end": {
+                "date": "2022-04-13",
+            },
+        }
+    )
+    assert event.id == "some-event-id"
+    assert event.summary == "Event summary"
+    assert event.description == "Event description"
+    assert event.location == "Event location"
+    assert event.start == datetime.date(2022, 4, 12)
+    assert event.end == datetime.date(2022, 4, 13)
+
+
+def test_event_datetime() -> None:
+    """Exercise basic parsing of an event API response."""
+
+    event = Event.parse_obj(
+        {
+            "kind": "calendar#event",
+            "id": "some-event-id",
+            "status": "some-status",
+            "summary": "Event summary",
+            "start": {
+                "dateTime": "2022-04-12T16:30:00-08:00",
+            },
+            "end": {
+                "dateTime": "2022-04-12T17:00:00-08:00",
+            },
+        }
+    )
+    assert event.id == "some-event-id"
+    assert event.summary == "Event summary"
+    assert event.description is None
+    assert event.location is None
+    tz = datetime.timezone(datetime.timedelta(hours=-8))
+    assert isinstance(event.start, datetime.datetime)
+    assert event.start == datetime.datetime(2022, 4, 12, 16, 30, 0, tzinfo=tz)
+    assert isinstance(event.end, datetime.datetime)
+    assert event.end == datetime.datetime(2022, 4, 12, 17, 0, 0, tzinfo=tz)


### PR DESCRIPTION
Add calendar and even pydantic data model, and address mypy coverage.

The CalendarList and Event objects are chosen using initial set of fields known to be used by Home Assistant.